### PR TITLE
changes to emonpi lcd emonPiLCD.py to take arguments from config file…

### DIFF
--- a/lcd/emonPiLCD
+++ b/lcd/emonPiLCD
@@ -18,7 +18,10 @@ DAEMON_NAME=emonPiLCD
 # This next line determines what user the script runs as.
 # Root generally not recommended but necessary if you are using the Raspberry Pi GPIO from Python.
 DAEMON_USER=root
- 
+
+EMONLCD_CONFIG="/home/debian/emonpi/lcd/emonPiLCD.conf"
+DAEMON_ARGS="--config-file $EMONLCD_CONFIG"
+
 # The process ID of the script when it runs is stored here:
 PIDFILE=/var/run/$DAEMON_NAME.pid
  
@@ -26,8 +29,8 @@ PIDFILE=/var/run/$DAEMON_NAME.pid
  
 do_start () {
     log_daemon_msg "Starting system $DAEMON_NAME daemon"
-    start-stop-daemon --start --background --pidfile $PIDFILE --make-pidfile --user $DAEMON_USER --chuid $DAEMON_USER --startas /bin/bash -- -c "exec $DAEMON > /var/log/emonpilcd.log 2>&1"
-    log_end_msg $?
+
+    start-stop-daemon --start --background --pidfile $PIDFILE --make-pidfile --user $DAEMON_USER --chuid $DAEMON_USER --startas /bin/bash -- -c "exec $DAEMON > /var/log/emonpilcd.log 2>&1" -- \ %DAEMON_ARGS \   log_end_msg $?
 }
 do_stop () {
     log_daemon_msg "Stopping system $DAEMON_NAME daemon"

--- a/lcd/emonPiLCD.conf
+++ b/lcd/emonPiLCD.conf
@@ -1,0 +1,54 @@
+######################################################################
+######################      emonPiLCD.conf     ########################
+#######################################################################
+###
+### SPECIMEN emonPiLCD configuration file
+### Note that when installed from apt, a new config file is written
+### by the debian/postinst script, so changing this file will do
+### nothing in and of itself.
+###
+### Each Interfacer and each Reporter has
+### - a [[name]]: a unique string
+### - a type: the name of the class it instantiates
+### - a set of init_settings (depends on the type)
+### - a set of runtimesettings (depends on the type)
+### Both init_settings and runtimesettings sections must be defined,
+### even if empty. Init settings are used at initialization,
+### and runtime settings are refreshed on a regular basis.
+### Many settings below are "commented out" as they are not mandatory and
+### have been included as a template or to provide alternative options
+### removing the leading # will enable the setting and override the default
+### Default settings are shown as comments on the same line as the setting
+### eg #(default:xyz) "xyz" is set if the setting is "commented out".
+###
+### All lines beginning with '###' are comments and can be safely removed.
+###
+#######################################################################
+#######################    emonPi LCD  settings    #######################
+#######################################################################
+
+# MUST BE LOWER CASE
+# dont change default
+
+[emonPiLCD]
+emonPi_nodeID = 10    # >> conf
+uselogfile = True    # >> conf
+mqtt_rx_channel = emonhub/rx/#
+mqtt_push_channel = emonhub/tx/#    # >> conf
+loghandler_path = /var/log/emonPiLCD
+#logger_level = logging.INFO
+
+backlight_timeout = 180
+SHUTDOWN_TIME = 3   # seconds   
+GPIO_PORT = P8_11    # >> conf
+GPIO_PORT_shutdown = P8_12    # >> conf
+max_number_pages = 6    # >> conf ??
+
+host = localhost
+port = 6379
+db = 0
+db2 : 1
+
+FromConfig = True
+# 
+

--- a/lcd/emonPiLCD.conf
+++ b/lcd/emonPiLCD.conf
@@ -31,7 +31,7 @@
 # dont change default
 
 [emonPiLCD]
-emonPi_nodeID = 10    # >> conf
+emonPi_nodeID =	5	# was 10 in file before changing to conf. 
 uselogfile = True    # >> conf
 mqtt_rx_channel = emonhub/rx/#
 mqtt_push_channel = emonhub/tx/#    # >> conf
@@ -45,9 +45,8 @@ GPIO_PORT_shutdown = P8_12    # >> conf
 max_number_pages = 6    # >> conf ??
 
 host = localhost
-port = 6379
-db = 0
-db2 : 1
+port = 6379   #
+db = 0	#123
 
 FromConfig = True
 # 

--- a/lcd/emonPiLCD.py
+++ b/lcd/emonPiLCD.py
@@ -17,35 +17,159 @@ import re
 import paho.mqtt.client as mqtt
 
 
+# ------------------------------------------------- 
+#     Config File reader
+# config file emonPiLCD.conf
+
+import ConfigParser
+from ConfigParser import RawConfigParser
+import re
+
+# parser
+
+import argparse
+
+parser = argparse.ArgumentParser(description='config file')
+
+parser.add_argument("--config-file", action="store", 
+		     help="path to config file", 
+                      default=sys.path[0] +'/emonPiLCD.conf')
+
+args = parser.parse_args()
+config_path = args.config_file
+print 'config path is ', config_path
+
+configfile = './emonPiLCD.conf'
+fullpath = '/home/debian/emonpi/lcd/emonPiLCD.conf'
+
+configs = ( )
+default = dict(
+    emonPi_nodeID = 10,
+    uselogfile = True,  
+    mqtt_rx_channel = 'emonhub/rx/#',
+    mqtt_push_channel = 'emonhub/tx/#',
+    loghandler_path = '/var/log/emonPiLCD',
+    #logger_level = logging.INFO,
+
+    backlight_timeout = 180,
+    SHUTDOWN_TIME = 3,
+    GPIO_PORT = 'P8_11',
+    GPIO_PORT_shutdown = 'P8_12',
+    max_number_pages = 6,
+
+    host = 'localhost',
+    port = 6379,
+    db = 0,
+    FromConfig = False
+)
+
+# -----------------------------
+#   loads config values from config file
+def read_config(filename):
+    global configs
+    err = 0
+    
+    #configs = ConfigParser.ConfigParser()
+    try:
+        configs.read( filename)    #config_path)
+	print 'read configs from cmd path\n Configs from .conf file is    ', configs.get('emonPiLCD', 'FromConfig')
+    except:
+        #error reading accessing file
+	print 'error reading config file from cmd-line path'
+	err = 1
+    if err ==1:
+        try:
+	    configs.read(fullpath)
+	except:
+	    err = 2
+	    print 'error reading fullpath too'
+
+    #print configs.items('emonPiLCD')
+
+
+# -----------------------------
+#   loads variable value from config
+def get_config( str ):
+    global configs
+
+    try:
+        val = configs.get('emonPiLCD', str)
+    except:
+        print 'no value nor default value, check name or add to default configuration'
+        return None
+
+    val = remove_comments( val )
+    try:
+        integer =  int(val)
+    except:
+        #print error
+        integer = val
+    
+    val = integer
+
+    if val == 'True' or val == 'true':
+        val = True
+    elif val == 'False' or val == 'false':
+        val = False
+
+    #print val, type(val)
+    return val
+
+
+# -----------------------------
+# removes comments on line strings
+def remove_comments(strin):
+    a = strin.find(' ')
+    if a>0:
+        return strin[:a] 
+    else:
+        return strin
+
+
+# ################################################
+#
+# ------------------- Config
+#
+
+# Load defaults
+configs = RawConfigParser(default, dict, True)      #print default.keys()
+
+# Load config file
+#read_config( configfile )
+read_config( config_path )
+
+
+
 # ------------------------------------------------------------------------------------
 # LCD backlight timeout in seconds
 # 0: always on
 # 300: off after 5 min
 # ------------------------------------------------------------------------------------
-backlight_timeout = 180
+backlight_timeout = get_config('backlight_timeout')    #180
 
 # ------------------------------------------------------------------------------------
 # emonPi Node ID (default 5)
 # ------------------------------------------------------------------------------------
-emonPi_nodeID = 10
+emonPi_nodeID = get_config('emonPi_nodeID')    #10
+
 lcd = lcddriver.lcd()
 
 
 # Default Startup Page
 page = 0
 inc = 0
-GPIO_PORT = "P8_11"
+GPIO_PORT = get_config('GPIO_PORT')    #"P8_11"
 
 #in case we use a button to switch on/off
-GPIO_PORT_shutdown = "P8_12"
+GPIO_PORT_shutdown = get_config('GPIO_PORT_shutdown')  #"P8_12"  
 GPIO.setup( GPIO_PORT,GPIO.IN)
 GPIO.setup( GPIO_PORT_shutdown,GPIO.IN)
 new_switch_state = GPIO.input(GPIO_PORT)
 shutdown_button =GPIO.input(GPIO_PORT_shutdown)
 
-max_number_pages = 6
+max_number_pages = get_config('max_number_pages')  #6
 
-SHUTDOWN_TIME =3  # Shutdown after 3 second press
+SHUTDOWN_TIME = get_config('SHUTDOWN_TIME')        #3  # Shutdown after 3 second press
 
 # ------------------------------------------------------------------------------------
 # Start Logging
@@ -53,29 +177,30 @@ SHUTDOWN_TIME =3  # Shutdown after 3 second press
 import logging
 import logging.handlers
 # NOTE this is during pilots remove this in future or move to proper log management
-uselogfile = True
+uselogfile = True    # >> conf
 
 mqttc = False
 mqttConnected = False
 basedata = []
-mqtt_rx_channel = "emonhub/rx/#"
-mqtt_push_channel = "emonhub/tx/#"
+mqtt_rx_channel =  "emonhub/rx/#"   #get_config('mqtt_rx_channel')   #"emonhub/rx/#"
+mqtt_push_channel = "emonhub/tx/#"    # >> conf
 
 if not uselogfile:
     loghandler = logging.StreamHandler()
 else:
-    loghandler = logging.handlers.RotatingFileHandler("/var/log/emonPiLCD",'a', 5000 * 1024, 1)
+    loghandler = logging.handlers.RotatingFileHandler("/var/log/emonPiLCD",'a', 5000 * 1024, 1)    # >> conf
 
 loghandler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
 logger = logging.getLogger("emonPiLCD")
 logger.addHandler(loghandler)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.INFO)    # >> conf
 
 logger.info("emonPiLCD Start")
 
 # ------------------------------------------------------------------------------------
 
-r = redis.Redis(host='localhost', port=6379, db=0)
+r = redis.Redis( host=get_config('host'), port=get_config('port'), db=get_config('db') ) 
+# host='localhost', port=6379, db=0)
 
 # We wait here until redis has successfully started up
 redisready = False


### PR DESCRIPTION
…, that path of which is given as terminal line argument in emonpilcd- service
I broke it then I fixed it.

added to the emonpilcd service file to give config file path
added to emonpilcd.py to take config path as argument
load variables from .conf file instead of having them fixed in python file

Broken for a while, fixed by setting unix filetype in vim, handling path corectly.
then it worked
