### PR TITLE
Add ConfigDownloader to download emonpo config file from the server

### DIFF
--- a/lcd/config_downloader.py
+++ b/lcd/config_downloader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import uuid
 import requests
+import codecs
 
 class ConfigDownloader:
     def __init__(self, config_path, remote_url):
@@ -19,8 +20,11 @@ class ConfigDownloader:
             exit()
         if self.download():
             print "writing config file to: " + self.config_path
-            self.save()
-            print "done."
+            if self.save():
+                print "done."
+            else:
+                print "error writing file:"
+                print self.error
         else:
             print "dowload failed:"
             print self.response
@@ -35,9 +39,14 @@ class ConfigDownloader:
           return False
 
     def save(self):
-        f = open(self.config_path,"w")
-        f.write(self.response.text)
-        f.close()
+        try:
+            f = codecs.open(self.config_path, "w", encoding='utf8')
+            f.write(self.response.text)
+            f.close()
+            return True
+        except Exception as e:
+            self.error = e
+            return False
 
 
 if __name__ == '__main__':

--- a/lcd/config_downloader.py
+++ b/lcd/config_downloader.py
@@ -6,7 +6,9 @@ class ConfigDownloader:
     def __init__(self, config_path, remote_url):
         self.config_path = config_path
         self.remote_url  = remote_url
-        self.api_key      = uuid.uuid4()
+        self.api_key     = uuid.uuid4()
+        self.error       = None
+        self.response    = None
 
     def run(self):
         print "Setting up a new account"
@@ -15,17 +17,22 @@ class ConfigDownloader:
         if ready != "":
             print "aborting..."
             exit()
-        self.download()
-        if self.response.status_code == requests.codes.ok:
+        if self.download():
             print "writing config file to: " + self.config_path
             self.save()
             print "done."
         else:
-            print "dowload failed with status: %s" % self.response.status_code
+            print "dowload failed:"
+            print self.response
+            print self.error
 
     def download(self):
-        self.response = requests.get(self.remote_url, headers={'X-Api-Key': self.api_key})
-        return self.response
+        try:
+          self.response = requests.get(self.remote_url, headers={'X-Api-Key': self.api_key})
+          return self.response.status_code == requests.codes.ok
+        except Exception as e:
+          self.error = e
+          return False
 
     def save(self):
         f = open(self.config_path,"w")

--- a/lcd/config_downloader.py
+++ b/lcd/config_downloader.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import uuid
+import requests
+
+class ConfigDownloader:
+    def __init__(self, config_path, remote_url):
+        self.config_path = config_path
+        self.remote_url  = remote_url
+        self.api_key      = uuid.uuid4()
+
+    def run(self):
+        print "Setting up a new account"
+        print "please make sure an account with API key %s is configured" % self.api_key
+        ready = raw_input("press return when ready... ")
+        if ready != "":
+            print "aborting..."
+            exit()
+        self.download()
+        if self.response.status_code == requests.codes.ok:
+            print "writing config file to: " + self.config_path
+            self.save()
+            print "done."
+        else:
+            print "dowload failed with status: %s" % self.response.status_code
+
+    def download(self):
+        self.response = requests.get(self.remote_url, headers={'X-Api-Key': self.api_key})
+        return self.response
+
+    def save(self):
+        f = open(self.config_path,"w")
+        f.write(self.response.text)
+        f.close()
+
+
+if __name__ == '__main__':
+    import os
+    config_path = os.environ.get('EMONPI_CONFIG', None)
+    remote_url  = os.environ.get('EMONPI_CONFIG_URL', None) or 'https://api.gle.solar/config'
+    if config_path == None or remote_url == None:
+        print "aborting. please provide a EMONPI_CONFIG path and an EMONPI_CONFIG_URL URL"
+        print "EMONPI_CONFIG: %s - EMONPI_CONFIG_URL: %s" % (config_path, remote_url)
+        exit()
+
+    ConfigDownloader(config_path, remote_url).run()
+


### PR DESCRIPTION
This adds a ConfigDownloader class to download the config file from a remote server and write it locally. 
It can either be used standalone `python config_downloader.py` or as an imported module.
